### PR TITLE
feat: adding event bus phase 1

### DIFF
--- a/docs/features/event-bus.md
+++ b/docs/features/event-bus.md
@@ -1,0 +1,252 @@
+# Event Bus System
+
+## Overview
+
+The Event Bus System enables asynchronous event communication between pandemic-core and infections through a distributed publish-subscribe architecture. This system allows infections to publish custom events and subscribe to events from other components, enabling real-time monitoring, inter-infection communication, audit logging, and reactive behaviors.
+
+The event bus uses separate Unix domain sockets per infection to provide security isolation, filesystem-based access control, and scalable event distribution without multiplexing complexity.
+
+## Requirements
+
+### Functional Requirements
+- [ ] Core daemon publishes system lifecycle events (infection start/stop/install/remove)
+- [ ] Infections can publish custom events to their dedicated event streams
+- [ ] Infections can subscribe to event streams from core and other infections
+- [ ] Topic-based event filtering using pattern matching
+- [ ] Event versioning with semantic versioning (default "1.0.0")
+- [ ] Control-plane management of event subscriptions through existing control socket
+
+### Non-Functional Requirements
+- [ ] Best-effort delivery (no persistence or guaranteed delivery)
+- [ ] Filesystem permissions for access control between infections
+- [ ] Rate limiting to prevent event spam
+- [ ] Minimal latency for real-time use cases
+- [ ] Scalable to hundreds of concurrent infections
+
+### Dependencies
+- Unix domain sockets support
+- Existing pandemic-core control socket infrastructure
+- File system permissions for security isolation
+- No backward compatibility requirements (net new feature)
+
+## Design
+
+### Architecture
+
+```
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│   pandemic-core │    │   infection-A   │    │   infection-B   │
+│                 │    │                 │    │                 │
+│  ┌───────────┐  │    │  ┌───────────┐  │    │  ┌───────────┐  │
+│  │ EventBus  │  │    │  │EventClient│  │    │  │EventClient│  │
+│  │ Manager   │  │    │  │           │  │    │  │           │  │
+│  └─────┬─────┘  │    │  └─────┬─────┘  │    │  └─────┬─────┘  │
+└────────┼────────┘    └────────┼────────┘    └────────┼────────┘
+         │                      │                      │
+         ▼                      ▼                      ▼
+/var/run/pandemic/events/       │                      │
+├── core.sock ◄─────────────────┼──────────────────────┘
+├── infection-A.sock ◄──────────┘
+└── infection-B.sock
+```
+
+### Event Socket Structure
+
+```
+/var/run/pandemic/
+├── control.sock              # Existing control channel
+└── events/
+    ├── core.sock            # Core daemon events (system-wide)
+    ├── infection-abc123.sock # Per-infection event streams
+    └── infection-xyz789.sock
+```
+
+### API Changes
+
+#### Event Message Format
+```json
+{
+  "eventId": "550e8400-e29b-41d4-a716-446655440000",
+  "version": "1.0.0",
+  "source": "core|infection-abc123",
+  "type": "infection.started|custom.metric|system.alert",
+  "timestamp": "2024-01-15T10:30:00.000Z",
+  "payload": {
+    "infectionId": "infection-abc123",
+    "customData": "..."
+  }
+}
+```
+
+#### Control Socket Commands
+
+**Subscribe to Events**
+```json
+{
+  "command": "subscribeEvents",
+  "payload": {
+    "infectionId": "infection-abc123",
+    "subscriptions": [
+      {"source": "core", "pattern": "infection.*"},
+      {"source": "infection-xyz789", "pattern": "custom.*"}
+    ]
+  }
+}
+```
+
+**Unsubscribe from Events**
+```json
+{
+  "command": "unsubscribeEvents", 
+  "payload": {
+    "infectionId": "infection-abc123",
+    "subscriptions": [
+      {"source": "core", "pattern": "infection.*"}
+    ]
+  }
+}
+```
+
+### Implementation Details
+
+#### Core Components
+
+**EventBus Manager (pandemic-core)**
+- Manages event socket creation and cleanup
+- Handles subscription routing and permissions
+- Implements rate limiting per connection
+- Publishes core system events
+
+**EventClient (pandemic-common)**
+- Provides simple publish/subscribe interface for infections
+- Manages socket connections to event streams
+- Handles event serialization/deserialization
+- Implements topic pattern matching
+
+**Event Router (pandemic-core)**
+- Routes events between publishers and subscribers
+- Enforces subscription permissions
+- Applies rate limiting policies
+
+#### Event Types
+
+**Core System Events**
+- `infection.installing` - Infection installation started
+- `infection.installed` - Infection installation completed
+- `infection.started` - Infection service started
+- `infection.stopped` - Infection service stopped
+- `infection.failed` - Infection operation failed
+- `system.health` - System health status changes
+
+**Custom Infection Events**
+- `custom.*` - Application-specific events
+- `metric.*` - Performance and monitoring metrics
+- `alert.*` - Alert and notification events
+- `audit.*` - Security and audit events
+
+#### Configuration
+```yaml
+eventBus:
+  enabled: true
+  eventsDir: "/var/run/pandemic/events"
+  rateLimit:
+    maxEventsPerSecond: 100
+    burstSize: 200
+  permissions:
+    defaultMode: "0660"
+    group: "pandemic"
+```
+
+## Examples
+
+### CLI Usage
+```bash
+# Subscribe to core events (via infection configuration)
+pandemic-cli configure infection-abc123 --event-subscriptions "core:infection.*"
+
+# View event subscriptions
+pandemic-cli status infection-abc123 --show-events
+```
+
+### API Usage
+```python
+# Publishing events from an infection
+from pandemic_common import EventClient
+
+client = EventClient(infection_id="infection-abc123")
+await client.publish("custom.metric", {
+    "cpu_usage": 85.2,
+    "memory_usage": 1024
+})
+
+# Subscribing to events
+async def handle_infection_events(event):
+    print(f"Infection {event.payload['infectionId']} changed state")
+
+await client.subscribe("core", "infection.*", handle_infection_events)
+```
+
+## Testing
+
+### Test Scenarios
+- [ ] Core daemon publishes system events correctly
+- [ ] Infections can publish and receive custom events
+- [ ] Topic pattern matching works correctly
+- [ ] Rate limiting prevents event spam
+- [ ] Filesystem permissions isolate infection access
+- [ ] Socket cleanup on infection removal
+- [ ] Multiple subscribers receive same events
+- [ ] Cross-infection communication works
+
+### Validation Criteria
+- Events delivered within 10ms for local sockets
+- Rate limiting triggers at configured thresholds
+- No memory leaks with long-running subscriptions
+- Proper socket cleanup on process termination
+
+## Migration
+
+### Breaking Changes
+- None (net new feature with no backward compatibility requirements)
+
+### Migration Steps
+1. Infections opt-in by using EventClient from pandemic-common
+2. Configure event subscriptions via control socket
+3. No changes required for existing infections
+
+### Rollback Plan
+- Disable event bus in configuration
+- Remove event socket directory
+- Infections gracefully handle missing event functionality
+
+## Implementation Plan
+
+### Phase 1: Core Infrastructure
+- [ ] EventBus manager in pandemic-core
+- [ ] Event socket creation and management
+- [ ] Basic publish/subscribe functionality
+- [ ] Event message format and serialization
+
+### Phase 2: Client Integration
+- [ ] EventClient in pandemic-common
+- [ ] Control socket commands for subscription management
+- [ ] Topic pattern matching
+- [ ] Rate limiting implementation
+
+### Phase 3: System Integration
+- [ ] Core daemon event publishing
+- [ ] Filesystem permissions and security
+- [ ] Configuration management
+- [ ] Error handling and cleanup
+
+### Phase 4: Testing & Documentation
+- [ ] Comprehensive test suite
+- [ ] Performance benchmarking
+- [ ] API documentation
+- [ ] Usage examples and tutorials
+
+## References
+
+- [System Design](../DESIGN.md) - Overall pandemic architecture
+- [Unix Domain Sockets](https://man7.org/linux/man-pages/man7/unix.7.html) - Transport mechanism
+- [Publish-Subscribe Pattern](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) - Design pattern reference

--- a/packages/pandemic-core/src/pandemic_core/config.py
+++ b/packages/pandemic-core/src/pandemic_core/config.py
@@ -24,6 +24,12 @@ class DaemonConfig:
     log_level: str = "INFO"
     structured_logging: bool = True
 
+    # Event bus configuration
+    event_bus_enabled: bool = True
+    events_dir: str = "/var/run/pandemic/events"
+    event_rate_limit: int = 100
+    event_burst_size: int = 200
+
     def __post_init__(self):
         if self.allowed_sources is None:
             self.allowed_sources = []
@@ -43,6 +49,7 @@ class DaemonConfig:
         storage_config = data.get("storage", {})
         security_config = data.get("security", {})
         logging_config = data.get("logging", {})
+        event_config = data.get("eventBus", {})
 
         return cls(
             socket_path=daemon_config.get("socket_path", cls.socket_path),
@@ -56,6 +63,14 @@ class DaemonConfig:
             allowed_sources=security_config.get("allowed_sources", cls.allowed_sources),
             log_level=logging_config.get("level", cls.log_level),
             structured_logging=logging_config.get("structured", cls.structured_logging),
+            event_bus_enabled=event_config.get("enabled", cls.event_bus_enabled),
+            events_dir=event_config.get("eventsDir", cls.events_dir),
+            event_rate_limit=event_config.get("rateLimit", {}).get(
+                "maxEventsPerSecond", cls.event_rate_limit
+            ),
+            event_burst_size=event_config.get("rateLimit", {}).get(
+                "burstSize", cls.event_burst_size
+            ),
         )
 
     @classmethod

--- a/packages/pandemic-core/src/pandemic_core/events.py
+++ b/packages/pandemic-core/src/pandemic_core/events.py
@@ -1,0 +1,197 @@
+"""Event bus system for pandemic daemon."""
+
+import asyncio
+import json
+import logging
+import os
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+from weakref import WeakSet
+
+
+@dataclass
+class Event:
+    """Event message structure."""
+
+    eventId: str
+    version: str
+    source: str
+    type: str
+    timestamp: str
+    payload: Dict[str, Any]
+
+    @classmethod
+    def create(
+        cls, source: str, event_type: str, payload: Dict[str, Any], version: str = "1.0.0"
+    ) -> "Event":
+        """Create a new event with generated ID and timestamp."""
+        return cls(
+            eventId=str(uuid.uuid4()),
+            version=version,
+            source=source,
+            type=event_type,
+            timestamp=datetime.utcnow().isoformat() + "Z",
+            payload=payload,
+        )
+
+    def to_json(self) -> str:
+        """Serialize event to JSON."""
+        return json.dumps(asdict(self))
+
+    @classmethod
+    def from_json(cls, data: str) -> "Event":
+        """Deserialize event from JSON."""
+        return cls(**json.loads(data))
+
+
+class EventSocket:
+    """Manages a single event socket for publishing/subscribing."""
+
+    def __init__(self, socket_path: str, source_id: str):
+        self.socket_path = socket_path
+        self.source_id = source_id
+        self.server: Optional[asyncio.Server] = None
+        self.subscribers: WeakSet = WeakSet()
+        self.logger = logging.getLogger(f"{__name__}.{source_id}")
+
+    async def start(self):
+        """Start the event socket server."""
+        socket_path = Path(self.socket_path)
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if socket_path.exists():
+            socket_path.unlink()
+
+        self.server = await asyncio.start_unix_server(
+            self._handle_subscriber, path=str(socket_path)
+        )
+
+        # Set socket permissions
+        os.chmod(socket_path, 0o660)
+
+        self.logger.debug(f"Event socket started: {socket_path}")
+
+    async def stop(self):
+        """Stop the event socket server."""
+        if self.server:
+            self.server.close()
+            await self.server.wait_closed()
+
+        socket_path = Path(self.socket_path)
+        if socket_path.exists():
+            socket_path.unlink()
+
+        self.logger.debug(f"Event socket stopped: {socket_path}")
+
+    async def publish(self, event: Event):
+        """Publish event to all subscribers."""
+        if not self.subscribers:
+            return
+
+        event_data = event.to_json().encode("utf-8")
+        event_length = len(event_data).to_bytes(4, "big")
+        message = event_length + event_data
+
+        # Send to all subscribers (best effort)
+        disconnected = []
+        for writer in list(self.subscribers):
+            try:
+                writer.write(message)
+                await writer.drain()
+            except Exception as e:
+                self.logger.debug(f"Failed to send event to subscriber: {e}")
+                disconnected.append(writer)
+
+        # Clean up disconnected subscribers
+        for writer in disconnected:
+            self.subscribers.discard(writer)
+
+    async def _handle_subscriber(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        """Handle new subscriber connection."""
+        self.subscribers.add(writer)
+        self.logger.debug(f"New subscriber connected to {self.source_id}")
+
+        try:
+            # Keep connection alive until client disconnects
+            while True:
+                data = await reader.read(1024)
+                if not data:
+                    break
+        except Exception as e:
+            self.logger.debug(f"Subscriber error: {e}")
+        finally:
+            self.subscribers.discard(writer)
+            writer.close()
+            await writer.wait_closed()
+            self.logger.debug(f"Subscriber disconnected from {self.source_id}")
+
+
+class EventBusManager:
+    """Manages event sockets and routing for the pandemic daemon."""
+
+    def __init__(self, events_dir: str = "/var/run/pandemic/events"):
+        self.events_dir = events_dir
+        self.sockets: Dict[str, EventSocket] = {}
+        self.logger = logging.getLogger(__name__)
+
+    async def start(self):
+        """Start the event bus manager."""
+        self.logger.info("Starting event bus manager")
+
+        # Create core event socket
+        await self.create_event_socket("core")
+
+    async def stop(self):
+        """Stop the event bus manager."""
+        self.logger.info("Stopping event bus manager")
+
+        # Stop all event sockets
+        for socket in self.sockets.values():
+            await socket.stop()
+
+        self.sockets.clear()
+
+    async def create_event_socket(self, source_id: str) -> EventSocket:
+        """Create a new event socket for the given source."""
+        if source_id in self.sockets:
+            return self.sockets[source_id]
+
+        socket_path = os.path.join(self.events_dir, f"{source_id}.sock")
+        event_socket = EventSocket(socket_path, source_id)
+
+        await event_socket.start()
+        self.sockets[source_id] = event_socket
+
+        self.logger.debug(f"Created event socket for {source_id}")
+        return event_socket
+
+    async def remove_event_socket(self, source_id: str):
+        """Remove an event socket."""
+        if source_id in self.sockets:
+            await self.sockets[source_id].stop()
+            del self.sockets[source_id]
+            self.logger.debug(f"Removed event socket for {source_id}")
+
+    async def publish_event(self, source_id: str, event_type: str, payload: Dict[str, Any]):
+        """Publish an event from the specified source."""
+        if source_id not in self.sockets:
+            self.logger.warning(f"No event socket for source: {source_id}")
+            return
+
+        event = Event.create(source_id, event_type, payload)
+        await self.sockets[source_id].publish(event)
+
+        self.logger.debug(f"Published event {event_type} from {source_id}")
+
+    def get_socket_path(self, source_id: str) -> Optional[str]:
+        """Get the socket path for a source."""
+        if source_id in self.sockets:
+            return self.sockets[source_id].socket_path
+        return None
+
+    def list_sources(self) -> List[str]:
+        """List all active event sources."""
+        return list(self.sockets.keys())

--- a/packages/pandemic-core/src/pandemic_core/events.py
+++ b/packages/pandemic-core/src/pandemic_core/events.py
@@ -70,7 +70,7 @@ class EventSocket:
         )
 
         # Set socket permissions
-        os.chmod(socket_path, 0o660)
+        os.chmod(socket_path, 0o600)
 
         self.logger.debug(f"Event socket started: {socket_path}")
 

--- a/packages/pandemic-core/tests/conftest.py
+++ b/packages/pandemic-core/tests/conftest.py
@@ -28,6 +28,8 @@ def test_config(temp_dir):
         config_dir=str(temp_dir / "config"),
         log_level="DEBUG",
         validate_signatures=False,
+        # TODO: Thsi is temperary until Phase 4 is implemented in the event bus spec
+        event_bus_enabled=False,
     )
 
 


### PR DESCRIPTION
- Adding a local event bus that uses a unix socket, which can be layered for other extensions

> I want to revisit another feature in pandemic-core. In the design for the system, we discussed a subscription system, allowing customers to respond to events in the system. I've been thinking more about this, and I want to expand this into a larger feature. Are you ready to brainstorm with me? I was thinking we should make an event bus allowing events from core daemon and other infections to push events.
